### PR TITLE
Change deleting image by from name to from ID

### DIFF
--- a/vars/removeAllImages.groovy
+++ b/vars/removeAllImages.groovy
@@ -7,5 +7,5 @@
  * @return not used
  */
 def call(String imageNameRegex) {
-    this.sh("docker images --format \"{{.Repository}}\" | grep ${imageNameRegex} | xargs -r docker rmi")
+    this.sh("docker images | grep ${imageNameRegex} | awk '{ print \$3; }' | xargs -r docker rmi")
 }


### PR DESCRIPTION
## Changelog

### Changed

- Delete Docker image by ID
  * In some scenarios `docker images` shows inconsistent image tags by flashing from "latest" to "none". This makes `docker rmi` command fails because the command expects a tag when we delete image by "name"
  * Not sure if it's a Docker bug, Horme now switch to passing ID to `docker rmi`
