### PR TITLE
Force deleting docker image

### DIFF
--- a/vars/removeAllImages.groovy
+++ b/vars/removeAllImages.groovy
@@ -7,5 +7,5 @@
  * @return not used
  */
 def call(String imageNameRegex) {
-    this.sh("docker images | grep ${imageNameRegex} | awk '{ print \$3; }' | xargs -r docker rmi")
+    this.sh("docker images | grep ${imageNameRegex} | awk '{ print \$3; }' | xargs -r docker rmi --force")
 }


### PR DESCRIPTION
## Changelog

### Added

### Changed

- Force deleting docker image

### Deprecated

### Removed

### Fixed

### Security

## Reference 

- [Force deleting image](https://bobcares.com/blog/docker-unable-to-delete-image-must-be-forced/)
